### PR TITLE
Convert from invariant strings instead of culture-dependent strings.

### DIFF
--- a/Nerdle.AutoConfig/Mappers/ValueMapper.cs
+++ b/Nerdle.AutoConfig/Mappers/ValueMapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Xml.Linq;
 
 namespace Nerdle.AutoConfig.Mappers
@@ -9,7 +10,7 @@ namespace Nerdle.AutoConfig.Mappers
         public virtual object Map(XElement element, Type type)
         {
             var converter = TypeDescriptor.GetConverter(type);
-            return converter.ConvertFromString(element.Value);
+            return converter.ConvertFromInvariantString(element.Value);
         }
 
         public virtual bool CanMap(Type type)

--- a/Nerdle.AutoConfig/Mapping/MappingFromAttribute.cs
+++ b/Nerdle.AutoConfig/Mapping/MappingFromAttribute.cs
@@ -21,7 +21,7 @@ namespace Nerdle.AutoConfig.Mapping
         {
             try
             {
-                var value = TypeDescriptor.GetConverter(_property.PropertyType).ConvertFromString(_attribute.Value);
+                var value = TypeDescriptor.GetConverter(_property.PropertyType).ConvertFromInvariantString(_attribute.Value);
                 _property.SetValue(instance, value, null);
             }
             catch (Exception ex)


### PR DESCRIPTION
I was running the unit tests on a "DE"-localized system. Some of them failed because of differences in string-parsing (e.g. "1.9" cannot be parsed into a double since it's expected to be "1,9"). But I guess we really want invariant parsing here.
