### PR TITLE
Support missing xml elements for nullable properties.

### DIFF
--- a/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFactoryTests/When_creating_a_mapping.cs
+++ b/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFactoryTests/When_creating_a_mapping.cs
@@ -37,6 +37,37 @@ namespace Nerdle.AutoConfig.Tests.Unit.Mapping.MappingFactoryTests
         }
 
         [Test]
+        public void A_mapping_is_created_for_nullable_properties_when_no_element_is_present()
+        {
+            var xElement = XElement.Parse("<foo></foo>");
+            _strategy.Setup(s => s.ForProperty(It.IsAny<PropertyInfo>())).Returns(MappingStrategy.DefaultNullablePropertyStrategy);
+            var mapping = _mappingFactory.CreateMapping(typeof(FooWithNullableInt), xElement, _strategy.Object);
+
+            mapping.Should().NotBeNull();
+        }
+
+        [Test]
+        public void A_mapping_is_created_for_nullable_properties_when_element_is_present()
+        {
+            var xElement = XElement.Parse("<foo><bar>1</bar></foo>");
+            _strategy.Setup(s => s.ForProperty(It.IsAny<PropertyInfo>())).Returns(MappingStrategy.DefaultNullablePropertyStrategy);
+            var mapping = _mappingFactory.CreateMapping(typeof(FooWithNullableInt), xElement, _strategy.Object);
+
+            mapping.Should().NotBeNull();
+        }
+
+        [Test]
+        public void A_mapping_for_nullable_properties_has_the_value_set()
+        {
+            var nullableFoo = new FooWithNullableInt();
+            var xElement = XElement.Parse("<foo><bar>1</bar></foo>");
+            _strategy.Setup(s => s.ForProperty(It.IsAny<PropertyInfo>())).Returns(MappingStrategy.DefaultNullablePropertyStrategy);
+            _mappingFactory.CreateMapping(typeof(FooWithNullableInt), xElement, _strategy.Object).Apply(nullableFoo);
+
+            nullableFoo.Bar.Should().Be(1);
+        }
+
+        [Test]
         public void Only_settable_public_properties_are_matched()
         {
             var xElement = XElement.Parse("<foo><bar>1</bar><baz>2</baz></foo>");
@@ -181,6 +212,11 @@ namespace Nerdle.AutoConfig.Tests.Unit.Mapping.MappingFactoryTests
     {
         public int Bar { get; set; }
         public int Baz { get; set; }
+    }
+
+    class FooWithNullableInt
+    {
+        public int? Bar { get; set; }
     }
 
     class FooWithSomeNonPublicStuff : Foo

--- a/Nerdle.AutoConfig.Tests.Unit/Strategy/ConfigureMappingStrategyTests/When_configuring_a_mapping_strategy.cs
+++ b/Nerdle.AutoConfig.Tests.Unit/Strategy/ConfigureMappingStrategyTests/When_configuring_a_mapping_strategy.cs
@@ -49,6 +49,14 @@ namespace Nerdle.AutoConfig.Tests.Unit.Strategy.ConfigureMappingStrategyTests
         }
 
         [Test]
+        public void A_default_nullable_Property_strategy_is_used_if_no_strategy_configured_for_the_specific_property()
+        {
+            var bar = typeof(IFooWithNullableInt).GetProperty("Bar");
+            _strategy.ForProperty(bar).Should().NotBeNull();
+            _strategy.ForProperty(bar).Should().Be(MappingStrategy.DefaultNullablePropertyStrategy);
+        }
+
+        [Test]
         public void Strategy_configuration_is_additive()
         {
             _strategy.Map(foo => foo.Bar).From("foo").OptionalWithDefault("one");
@@ -67,5 +75,10 @@ namespace Nerdle.AutoConfig.Tests.Unit.Strategy.ConfigureMappingStrategyTests
     interface IFoo
     {
         string Bar { get; }
+    }
+
+    interface IFooWithNullableInt
+    {
+        int? Bar { get; }
     }
 }

--- a/Nerdle.AutoConfig/Strategy/MappingStrategy.cs
+++ b/Nerdle.AutoConfig/Strategy/MappingStrategy.cs
@@ -11,6 +11,7 @@ namespace Nerdle.AutoConfig.Strategy
         protected ConcurrentDictionary<string, PropertyStrategy> PropertyStrategies { get; private set; }
 
         public static readonly PropertyStrategy DefaultPropertyStrategy = new PropertyStrategy();
+        public static readonly PropertyStrategy DefaultNullablePropertyStrategy = new NullablePropertyStrategy();
 
         public ICaseConverter CaseConverter { get; protected set; }
 
@@ -34,7 +35,10 @@ namespace Nerdle.AutoConfig.Strategy
         {
             PropertyStrategy strategy;
             return PropertyStrategies.TryGetValue(KeyFor(property), out strategy)
-                ? strategy : DefaultPropertyStrategy;
+                ? strategy
+                : Nullable.GetUnderlyingType(property.PropertyType) != null
+                    ? DefaultNullablePropertyStrategy
+                    : DefaultPropertyStrategy;
         }
 
         static string KeyFor(PropertyInfo property)

--- a/Nerdle.AutoConfig/Strategy/PropertyStrategy.cs
+++ b/Nerdle.AutoConfig/Strategy/PropertyStrategy.cs
@@ -17,4 +17,12 @@ namespace Nerdle.AutoConfig.Strategy
         public object DefaultValue { get; protected set; }
         public IMapper Mapper { get; protected set; }
     }
+
+    class NullablePropertyStrategy : PropertyStrategy
+    {
+        public NullablePropertyStrategy()
+        {
+            base.IsOptional = true;
+        }
+    }
 }


### PR DESCRIPTION
Since a nullable property can be implicitly considered optional, a missing element should not fail the mapping.
