### PR TITLE
Parse only defined enum values, also for attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dotnet: 2.1.300
 solution: Nerdle.AutoConfig.sln
 install:
   - nuget restore Nerdle.AutoConfig.sln
-  - nuget install NUnit.ConsoleRunner -Version 3.9.0 -OutputDirectory testrunner
+  - nuget install NUnit.ConsoleRunner -Version 3.10.0 -OutputDirectory testrunner
 script:
   - msbuild /p:Configuration=Release Nerdle.AutoConfig.sln
-  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Nerdle.AutoConfig.Tests.Unit/bin/Release/net4*/Nerdle.AutoConfig.Tests.Unit.dll
-  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Nerdle.AutoConfig.Tests.Integration/bin/Release/net4*/Nerdle.AutoConfig.Tests.Integration.dll
+  - mono ./testrunner/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe ./Nerdle.AutoConfig.Tests.Unit/bin/Release/net4*/Nerdle.AutoConfig.Tests.Unit.dll
+  - mono ./testrunner/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe ./Nerdle.AutoConfig.Tests.Integration/bin/Release/net4*/Nerdle.AutoConfig.Tests.Integration.dll
   - dotnet vstest ./Nerdle.AutoConfig.Tests.Unit/bin/Release/netcore*/Nerdle.AutoConfig.Tests.Unit.dll
   - dotnet vstest ./Nerdle.AutoConfig.Tests.Integration/bin/Release/netcore*/Nerdle.AutoConfig.Tests.Integration.dll

--- a/Nerdle.AutoConfig.Tests.Integration/Nerdle.AutoConfig.Tests.Integration.csproj
+++ b/Nerdle.AutoConfig.Tests.Integration/Nerdle.AutoConfig.Tests.Integration.csproj
@@ -9,10 +9,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nerdle.AutoConfig\Nerdle.AutoConfig.csproj" />

--- a/Nerdle.AutoConfig.Tests.Unit/Mappers/ValueMapperTests/When_mapping_simple_types.cs
+++ b/Nerdle.AutoConfig.Tests.Unit/Mappers/ValueMapperTests/When_mapping_simple_types.cs
@@ -29,7 +29,8 @@ namespace Nerdle.AutoConfig.Tests.Unit.Mappers.ValueMapperTests
         public void Using_an_undefined_enum_value_should_throw()
         {
             var xElement = XElement.Parse("<test>1234</test>");
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _sut.Map(xElement, typeof(DayOfWeek)));
+            Action mapping = () => _sut.Map(xElement, typeof(DayOfWeek));
+            var exception = mapping.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
             exception.ActualValue.Should().Be((DayOfWeek)1234);
             exception.Message.Should().Contain("'1234'");
             exception.Message.Should().Contain("'System.DayOfWeek'");

--- a/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFromAttributeTests/When_mapping_a_property.cs
+++ b/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFromAttributeTests/When_mapping_a_property.cs
@@ -50,6 +50,7 @@ namespace Nerdle.AutoConfig.Tests.Unit.Mapping.MappingFromAttributeTests
                 .And.Subject.Should().Contain("1234")
                 .And.Subject.Should().Contain(propertyInfo.Name)
                 .And.Subject.Should().Contain(typeof(Foo).Name);
+            exception.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
         }
     }
 

--- a/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFromAttributeTests/When_mapping_a_property.cs
+++ b/Nerdle.AutoConfig.Tests.Unit/Mapping/MappingFromAttributeTests/When_mapping_a_property.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Xml.Linq;
 using FluentAssertions;
 using Nerdle.AutoConfig.Exceptions;
@@ -11,36 +10,52 @@ namespace Nerdle.AutoConfig.Tests.Unit.Mapping.MappingFromAttributeTests
     [TestFixture]
     public class When_mapping_a_property
     {
-        readonly PropertyInfo _propertyInfo = typeof(Foo).GetProperty("Bar");
-
         [Test]
         public void The_property_is_set_using_an_internal_conversion()
         {
             var xAttribute = new XAttribute("whatever", "42");
-            var sut = new MappingFromAttribute(xAttribute, _propertyInfo);
+            var propertyInfo = typeof(Foo).GetProperty(nameof(Foo.AnInt));
+            var sut = new MappingFromAttribute(xAttribute, propertyInfo);
             var instance = new Foo();
             sut.Apply(instance);
-            instance.Bar.Should().Be(42);
+            instance.AnInt.Should().Be(42);
         }
 
         [Test]
         public void A_mapping_exception_is_thrown_if_the_conversion_throws()
         {
             var xAttribute = new XAttribute("theAttributeName", "theInvalidValue");
-            var sut = new MappingFromAttribute(xAttribute, _propertyInfo);
+            var propertyInfo = typeof(Foo).GetProperty(nameof(Foo.AnInt));
+            var sut = new MappingFromAttribute(xAttribute, propertyInfo);
             var instance = new Foo();
             Action mapping = () => sut.Apply(instance);
             var exception = mapping.Should().ThrowExactly<AutoConfigMappingException>().Which;
             exception.Message.Should().Contain("theAttributeName")
                 .And.Subject.Should().Contain("theInvalidValue")
-                .And.Subject.Should().Contain(_propertyInfo.Name)
+                .And.Subject.Should().Contain(propertyInfo.Name)
                 .And.Subject.Should().Contain(typeof(Foo).Name);
             exception.InnerException.Message.Should().Contain("theInvalidValue is not a valid value for Int32.");
+        }
+        
+        [Test]
+        public void A_mapping_exception_is_thrown_if_an_enum_is_undefined()
+        {
+            var xAttribute = new XAttribute("theAttributeName", "1234");
+            var propertyInfo = typeof(Foo).GetProperty(nameof(Foo.AnEnum));
+            var sut = new MappingFromAttribute(xAttribute, propertyInfo);
+            var instance = new Foo();
+            Action mapping = () => sut.Apply(instance);
+            var exception = mapping.Should().ThrowExactly<AutoConfigMappingException>().Which;
+            exception.Message.Should().Contain("theAttributeName")
+                .And.Subject.Should().Contain("1234")
+                .And.Subject.Should().Contain(propertyInfo.Name)
+                .And.Subject.Should().Contain(typeof(Foo).Name);
         }
     }
 
     class Foo
     {
-        public int Bar { get; set; }
+        public int AnInt { get; set; }
+        public DayOfWeek AnEnum { get; set; }
     }
 }

--- a/Nerdle.AutoConfig.Tests.Unit/Nerdle.AutoConfig.Tests.Unit.csproj
+++ b/Nerdle.AutoConfig.Tests.Unit/Nerdle.AutoConfig.Tests.Unit.csproj
@@ -4,11 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nerdle.AutoConfig\Nerdle.AutoConfig.csproj" />

--- a/Nerdle.AutoConfig/Extensions/TypeExtensions.cs
+++ b/Nerdle.AutoConfig/Extensions/TypeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -51,6 +52,18 @@ namespace Nerdle.AutoConfig.Extensions
                 sectionName = sectionName.Substring(1);
 
             return sectionName;
+        }
+
+        public static object ConvertFromInvariantString(this Type type, string value)
+        {
+            var converter = TypeDescriptor.GetConverter(type);
+            var result = converter.ConvertFromInvariantString(value);
+            if (type.IsEnum && result != null && !type.IsEnumDefined(result))
+            {
+                var definedValues = Enum.GetValues(type).Cast<object>().Select(e => e.ToString());
+                throw new ArgumentOutOfRangeException(nameof(value), result, $"Failed to convert '{value}' into '{type}' because it is not a defined value of the enum type. Defined values: '{string.Join("', '", definedValues)}'");
+            }
+            return result;
         }
     }
 }

--- a/Nerdle.AutoConfig/Mapping/Mappers/ValueMapper.cs
+++ b/Nerdle.AutoConfig/Mapping/Mappers/ValueMapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Xml.Linq;
+using Nerdle.AutoConfig.Extensions;
 
 namespace Nerdle.AutoConfig.Mapping.Mappers
 {
@@ -9,14 +9,7 @@ namespace Nerdle.AutoConfig.Mapping.Mappers
     {
         public object Map(XElement element, Type type)
         {
-            var converter = TypeDescriptor.GetConverter(type);
-            var result = converter.ConvertFromInvariantString(element.Value);
-            if (type.IsEnum && result != null && !type.IsEnumDefined(result))
-            {
-                var definedValues = Enum.GetValues(type).Cast<object>().Select(e => e.ToString());
-                throw new ArgumentOutOfRangeException(nameof(element), result, $"Failed to convert '{element.Value}' into '{type}' because it is not a defined value of the enum type. Defined values: '{string.Join("', '", definedValues)}'");
-            }
-            return result;
+            return type.ConvertFromInvariantString(element.Value);
         }
 
         public bool CanMap(Type type)

--- a/Nerdle.AutoConfig/Mapping/MappingFromAttribute.cs
+++ b/Nerdle.AutoConfig/Mapping/MappingFromAttribute.cs
@@ -1,8 +1,8 @@
 using System;
-using System.ComponentModel;
 using System.Reflection;
 using System.Xml.Linq;
 using Nerdle.AutoConfig.Exceptions;
+using Nerdle.AutoConfig.Extensions;
 
 namespace Nerdle.AutoConfig.Mapping
 {
@@ -21,7 +21,7 @@ namespace Nerdle.AutoConfig.Mapping
         {
             try
             {
-                var value = TypeDescriptor.GetConverter(_property.PropertyType).ConvertFromInvariantString(_attribute.Value);
+                var value = _property.PropertyType.ConvertFromInvariantString(_attribute.Value);
                 _property.SetValue(instance, value, null);
             }
             catch (Exception ex)


### PR DESCRIPTION
In my previous pull request (#17) an exception would be thrown for undefined enum values only when mapping an element. Now, both elements and attributes with undefined enum values throw an ArgumentOutOfRangeException.