### PR TITLE
Add support for configuring property mapping through attributes

### DIFF
--- a/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategy.cs
+++ b/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Xml.Linq;
 using FluentAssertions;
 using Nerdle.AutoConfig.Mapping.Mappers;
@@ -70,6 +71,14 @@ namespace Nerdle.AutoConfig.Tests.Integration
             config.Baz.Should().Be("baz");
             config.Qux.Should().Be("From custom mapper");
         }
+        
+        [Test]
+        public void Configuring_the_mapping_with_both_fluent_api_and_default_value_attribute()
+        {
+            AutoConfig.WhenMapping<IDefaultValueConfiguration>(mapper => mapper.Map(x => x.Foo).OptionalWithDefault("default_from_fluent_api"));
+            var config = AutoConfig.Map<IDefaultValueConfiguration>(configFilePath: ConfigFilePath);
+            config.Foo.Should().Be("default_from_fluent_api");
+        }
     }
 
     public interface ICustomConfiguration
@@ -80,6 +89,12 @@ namespace Nerdle.AutoConfig.Tests.Integration
         string Qux { get; }
     }
 
+    public interface IDefaultValueConfiguration
+    {
+        [DefaultValue("default_from_attribute")]
+        string Foo { get; }
+    }
+    
     class CustomMapper : IMapper
     {
         public object Map(XElement element, Type type)

--- a/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategy.xml
+++ b/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategy.xml
@@ -3,11 +3,14 @@
 
   <configSections>
     <section name="CustomConfiguration" type="Nerdle.AutoConfig.Section, Nerdle.AutoConfig" />
+    <section name="defaultValueConfiguration" type="Nerdle.AutoConfig.Section, Nerdle.AutoConfig" />
   </configSections>
 
   <CustomConfiguration>
     <foofoo>fooooo</foofoo>
     <Qux>qux</Qux>
   </CustomConfiguration>
+  
+  <defaultValueConfiguration/>
 
 </configuration>

--- a/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategyWithAttributes.cs
+++ b/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategyWithAttributes.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.ComponentModel;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nerdle.AutoConfig.Tests.Integration
+{
+    public enum Size {
+        Small,
+        Medium,
+        Large
+    }
+    
+    [TestFixture]
+    public class ConfiguringTheMappingStrategyWithAttributes : EndToEndTest
+    {
+        [Test]
+        public void Mapping_to_an_interface()
+        {
+            var config = AutoConfig.Map<ISimpleConfiguration>(configFilePath: ConfigFilePath);
+            config.Should().BeAssignableTo<ISimpleConfiguration>();
+            config.Should().NotBeNull();
+            config.MyString.Should().Be("hello");
+            config.MyInt.Should().Be(42);
+            config.MyDate1.Should().Be(new DateTime(1969, 07, 21));
+            config.MyDate2.Should().Be(new DateTime(1969, 07, 22));
+            config.MyBool.Should().BeTrue();
+            config.MyNullable.Should().Be(23);
+            config.MyEmptyNullable.Should().NotHaveValue();
+            config.MyTimeSpan1.Should().Be(TimeSpan.FromMinutes(5));
+            config.MyTimeSpan2.Should().Be(TimeSpan.FromMinutes(6));
+            config.MySize.Should().Be(Size.Medium);
+        }
+
+        [Test]
+        public void Mapping_to_a_concrete_class()
+        {
+            var config = AutoConfig.Map<SimpleConfiguration>(configFilePath: ConfigFilePath);
+            config.Should().BeOfType<SimpleConfiguration>();
+            config.Should().NotBeNull();
+            config.MyString.Should().Be("hello");
+            config.MyInt.Should().Be(42);
+            config.MyDate1.Should().Be(new DateTime(1969, 07, 21));
+            config.MyDate2.Should().Be(new DateTime(1969, 07, 22));
+            config.MyBool.Should().BeTrue();
+            config.MyNullable.Should().Be(23);
+            config.MyEmptyNullable.Should().NotHaveValue();
+            config.MyTimeSpan1.Should().Be(TimeSpan.FromMinutes(5));
+            config.MyTimeSpan2.Should().Be(TimeSpan.FromMinutes(6));
+            config.MySize.Should().Be(Size.Medium);
+        }
+
+        public interface ISimpleConfiguration
+        {
+            [DefaultValue("hello")]
+            string MyString { get; }
+            [DefaultValue(42)]
+            int MyInt { get; }
+            [DefaultValue("1969-07-21")]
+            DateTime MyDate1 { get; }
+            [DefaultValue(typeof(DateTime), "1969-07-22")]
+            DateTime MyDate2 { get; }
+            [DefaultValue(true)]
+            bool MyBool { get; }
+            [DefaultValue(23)]
+            int? MyNullable { get; }
+            [DefaultValue(null)]
+            int? MyEmptyNullable { get; }
+            [DefaultValue("00:05:00")]
+            TimeSpan MyTimeSpan1 { get; }
+            [DefaultValue(typeof(TimeSpan), "00:06:00")]
+            TimeSpan MyTimeSpan2 { get; }
+            [DefaultValue(Size.Medium)]
+            Size MySize { get; }
+        }
+
+        public class SimpleConfiguration
+        {
+            [DefaultValue("hello")]
+            public string MyString { get; set; }
+            [DefaultValue(42)]
+            public int MyInt { get; set; }
+            [DefaultValue("1969-07-21")]
+            public DateTime MyDate1 { get; set; }
+            [DefaultValue(typeof(DateTime), "1969-07-22")]
+            public DateTime MyDate2 { get; set; }
+            [DefaultValue(true)]
+            public bool MyBool { get; set; }
+            [DefaultValue(23)]
+            public int? MyNullable { get; set; }
+            [DefaultValue(null)]
+            public int? MyEmptyNullable { get; set; }
+            [DefaultValue("00:05:00")]
+            public TimeSpan MyTimeSpan1 { get; set; }
+            [DefaultValue(typeof(TimeSpan), "00:06:00")]
+            public TimeSpan MyTimeSpan2 { get; set; }
+            [DefaultValue(Size.Medium)]
+            public Size MySize { get; set; }
+        }
+    }
+}

--- a/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategyWithAttributes.xml
+++ b/Nerdle.AutoConfig.Tests.Integration/ConfiguringTheMappingStrategyWithAttributes.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+
+  <configSections>
+    <section name="simpleConfiguration" type="Nerdle.AutoConfig.Section, Nerdle.AutoConfig" />
+  </configSections>
+
+  <simpleConfiguration/>
+
+</configuration>

--- a/Nerdle.AutoConfig/Strategy/PropertyStrategy.cs
+++ b/Nerdle.AutoConfig/Strategy/PropertyStrategy.cs
@@ -12,6 +12,16 @@ namespace Nerdle.AutoConfig.Strategy
 
     class PropertyStrategy : IPropertyStrategy
     {
+        public PropertyStrategy()
+        {
+        }
+
+        public PropertyStrategy(object defaultValue)
+        {
+            IsOptional = true;
+            DefaultValue = defaultValue;
+        }
+
         public string MapFrom { get; protected set; }
         public bool IsOptional { get; protected set; }
         public object DefaultValue { get; protected set; }


### PR DESCRIPTION
If this gets merged then the wiki should probably be updated with sample code showing how to configure a default value with `System.ComponentModel.DefaultValueAttribute` as an alternative to the fluent API.