### PR TITLE
Configure project for cross-platform `dotnet pack`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: csharp
 dotnet: 2.1.801
+git:
+  depth: false
 solution: Nerdle.AutoConfig.sln
 install:
   - nuget restore Nerdle.AutoConfig.sln

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <!-- Required for building the .NET Framework target (net45) on Linux and macOS without mono.
+         Eventually, explicitly using the reference assemblies shouldn't be needed anymore, see https://github.com/dotnet/designs/pull/33#issuecomment-528457298 -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/Nerdle.AutoConfig/Nerdle.AutoConfig.csproj
+++ b/Nerdle.AutoConfig/Nerdle.AutoConfig.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Authors>edpollitt</Authors>
+    <Copyright>Copyright edpollitt 2015-2019</Copyright>
+    <Description>AutoConfig is an automagical, convention-based, customisable, extensible library for mapping configuration files to POCO C# objects/interfaces with the absolute minimum of code.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/edpollitt/Nerdle.AutoConfig</PackageProjectUrl>
+    <PackageTags>configuration mapper mapping map xml config autoconfig web.config app.config</PackageTags>
+    <RepositoryUrl>https://github.com/edpollitt/Nerdle.AutoConfig</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Configuration" Condition="'$(TargetFramework)' == 'net45'" />
@@ -10,4 +19,17 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.2.0" PrivateAssets="All" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+  <Target Name="FixAssemblyVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <!-- MinVer would set the assembly version to 1.0.0.0 but versions have already been published with 1.1.0.0, see https://github.com/adamralph/minver#version-numbers -->
+      <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/Nerdle.AutoConfig/Properties/AssemblyInfo.cs
+++ b/Nerdle.AutoConfig/Properties/AssemblyInfo.cs
@@ -1,39 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Nerdle.AutoConfig")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Nerdle.AutoConfig")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a98f42ab-c840-480a-a577-7332566fa7a5")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Nerdle.AutoConfig.Tests.Unit")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] 
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
* The PackageReference to `Microsoft.NETFramework.ReferenceAssemblies` in Directory.Build.props enables building the net45 target on Linux and macOS without having mono installed, just with the .NET Core SDK.

* The NuGet packaging information (authors, copyright, description etc.) is now in the `Nerdle.AutoConfig.csproj` file. All the properties are documented in [NuGet pack and restore as MSBuild targets][1].

* [SourceLink][2] was added for improved debugging experience.

Note that even though the SourceLink package is a preview, the format is stable:

> ##### Preview Status
> 
> We recommend using Source Link preview for building production packages. Although the implementation details and the public APIs of the Source Link pre-release packages are still in flux, there will be no difference in the format of the data it generates between preview and 1.0.0. The only changes in the generated data we expect are due to bug fixes that target scenario that previously did not work correctly.


* [MinVer][3] was chosen for versioning the package. It is *a minimalistic .NET package for versioning .NET SDK-style projects using Git tags.*

With all this in place, producing the NuGet package and [symbol package][4] becomes an easy two step process:

1. Add a tag with the version: `git tag v1.4.0`
2. Run `dotnet pack -c Release`

Both `Nerdle.AutoConfig.1.4.0.nupkg` and `Nerdle.AutoConfig.1.4.0.snupkg` will be produced, ready to be [published on NuGet][5].

[1]: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
[2]: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink
[3]: https://github.com/adamralph/minver
[4]: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
[5]: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package